### PR TITLE
Migrated GitHub Actions to supported versions

### DIFF
--- a/.github/workflows/check-development.yml
+++ b/.github/workflows/check-development.yml
@@ -134,18 +134,18 @@ jobs:
       ## Most of these steps are the same as the ones in
       ## https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
       ## If they update their steps, we will also need to update ours.
-      - uses: actions/checkout@v2      
+      - uses: actions/checkout@v4      
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
       
       - name: Install dependencies
         run: |
           sudo apt-get install libcurl4-openssl-dev libglpk-dev libmagick++-dev \
           libharfbuzz-dev libfribidi-dev
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-tinytex@master
+      - uses: r-lib/actions/setup-tinytex@v2
 
       # - name: Install latex packages
       #   run: |
@@ -197,7 +197,7 @@ jobs:
 
       - name: Cache R packages
         if: "!contains(github.event.head_commit.message, '/nocache')"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/_temp/Library
           key: ${{ env.cache-version }}-${{ runner.os }}-biocdocker-biocbranch-r-${{ steps.findrversion.outputs.rversion }}-bioc-${{ steps.findrversion.outputs.biocversionnum }}-${{ hashFiles('.github/depends.Rds') }}
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-biocdocker-biocbranch-r-${{ steps.findrversion.outputs.rversion }}-bioc-${{ steps.findrversion.outputs.biocversionnum }}-results
           path: check
@@ -370,18 +370,18 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup R from r-lib
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ needs.R-CMD-check.outputs.rversion }}
 
       - name: Setup pandoc from r-lib
-        uses: r-lib/actions/setup-pandoc@master
+        uses: r-lib/actions/setup-pandoc@v2
 
       - name: Setup tinytex from r-lib
-        uses: r-lib/actions/setup-tinytex@master
+        uses: r-lib/actions/setup-tinytex@v2
 
       # - name: Install latex packages
       #   run: |
@@ -401,7 +401,7 @@ jobs:
 
       - name: Cache R packages
         if: "!contains(github.event.head_commit.message, '/nocache')"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ env.cache-version }}-${{ runner.os }}-biocbranch-r-${{ needs.R-CMD-check.outputs.rversion }}-bioc-${{ needs.define-docker-info.outputs.biocversion }}-${{ hashFiles('.github/depends.Rds') }}
@@ -545,7 +545,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-biocbranch-${{ needs.R-CMD-check.outputs.biocversion }}-r-${{ needs.R-CMD-check.outputs.rversion }}-bioc-${{ needs.R-CMD-check.outputs.biocversion }}-results
           path: check

--- a/.github/workflows/check-master.yml
+++ b/.github/workflows/check-master.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Cache R packages
         if: "!contains(github.event.head_commit.message, '/nocache')"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: /home/runner/work/_temp/Library
           key: ${{ env.cache-version }}-${{ runner.os }}-biocdocker-biocbranch-r-${{ steps.findrversion.outputs.rversion }}-bioc-${{ steps.findrversion.outputs.biocversionnum }}-${{ hashFiles('.github/depends.Rds') }}
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-biocdocker-biocbranch-r-${{ steps.findrversion.outputs.rversion }}-bioc-${{ steps.findrversion.outputs.biocversionnum }}-results
           path: check
@@ -401,7 +401,7 @@ jobs:
 
       - name: Cache R packages
         if: "!contains(github.event.head_commit.message, '/nocache')"
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ env.cache-version }}-${{ runner.os }}-biocbranch-r-${{ needs.R-CMD-check.outputs.rversion }}-bioc-${{ needs.define-docker-info.outputs.biocversion }}-${{ hashFiles('.github/depends.Rds') }}
@@ -545,7 +545,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}-biocbranch-${{ needs.R-CMD-check.outputs.biocversion }}-r-${{ needs.R-CMD-check.outputs.rversion }}-bioc-${{ needs.R-CMD-check.outputs.biocversion }}-results
           path: check

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -15,18 +15,26 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: pkgdown
+          extra-packages: pkgdown,remotes
           needs: website
+
+      - name: Install Bioconductor packages
+        run: |
+          Rscript -e 'install.packages("BiocManager")'
+          Rscript -e 'BiocManager::install(c("GenomeInfoDb", "Biostrings", "dndscv"))'
+
+      - name: Install package
+        run: Rscript -e 'remotes::install_local(".", build_vignettes = FALSE)'
 
       - name: Deploy package
         run: |

--- a/vignettes/a7_Example_tumour_simulation.Rmd
+++ b/vignettes/a7_Example_tumour_simulation.Rmd
@@ -16,6 +16,7 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
+options(ragg.max_dim = 200000)
 ```
 
 <center>
@@ -80,11 +81,14 @@ ani = df %>%
     subtitle = 'Tumour doublings (clock): t = {closest_state}'
     ) +
   ggthemes::scale_fill_ptol() +
-  mobster:::my_ggplot_theme() 
+  mobster:::my_ggplot_theme()
 
-  gganimate::animate(ani,
+gganimate::animate(ani,
                    width = 480,
                    height = 480,
+                   units = "px",
+                   res = 72,
+                   nframes = 100,
                    renderer = gganimate::magick_renderer())
 ```
 


### PR DESCRIPTION
Replaced deprecated 'master' references and updated all affected r-lib and cache-related actions to their current stable releases. Also, updated vignette A7 which failed to build in pkgdown action due to memory issues related to resolution.