### PR TITLE
Updated GitHub links

### DIFF
--- a/R/get_clone_trees.R
+++ b/R/get_clone_trees.R
@@ -1,7 +1,7 @@
 #' Return clone trees from the fit.
 #' 
 #' @description This function uses the output fit of MOBSTER
-#' to create a call to \code{ctree} (\url{https://caravagn.github.io/ctree/}),
+#' to create a call to \code{ctree} (\url{https://caravagnalab.github.io/ctree/}),
 #' a package to create clone trees for cancer evolution models.
 #' 
 #' Creation of a clone tree requires annotations that are not usually 

--- a/R/mobster_fit.R
+++ b/R/mobster_fit.R
@@ -165,7 +165,7 @@ mobster_fit = function(x,
   # Fits are obtained using the easypar package
   # which allows easy parallelization of R functions
   #
-  # https://github.com/caravagn/easypar
+  # https://github.com/caravagnalab/easypar
   #
   # Inputs in the easypar format - list of lists
   # =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -35,7 +35,7 @@
     # pio::pioHdr('MOBSTER - Model-based clustering in cancer')
     # pio::pioStr("Author : ", "Giulio Caravagna <gcaravagn@gmail.com>", suffix = '\n')
     # pio::pioStr("GitHub : ", "caravagn/mobster", suffix = '\n')
-    # pio::pioStr("   WWW : ", "https://caravagn.github.io/mobster/", suffix = '\n')
+    # pio::pioStr("   WWW : ", "https://caravagnalab.github.io/mobster/", suffix = '\n')
     # 
     # 
     # cat(
@@ -46,7 +46,7 @@
     
     pk = 'mobster'
     pk_l = 'Model-based clustering in cancer'
-    www = "https://caravagn.github.io/mobster/"
+    www = "https://caravagnalab.github.io/mobster/"
     em = "gcaravagn@gmail.com"
     
     cli::cli_text("{crayon::green(clisymbols::symbol$tick)} Loading {.field {pk}}, {.emph \'{pk_l}\'}. Support : {.url { www}}.")

--- a/man/get_clone_trees.Rd
+++ b/man/get_clone_trees.Rd
@@ -17,7 +17,7 @@ The output of the constructor \code{ctree::cetrees}.
 }
 \description{
 This function uses the output fit of MOBSTER
-to create a call to \code{ctree} (\url{https://caravagn.github.io/ctree/}),
+to create a call to \code{ctree} (\url{https://caravagnalab.github.io/ctree/}),
 a package to create clone trees for cancer evolution models.
 
 Creation of a clone tree requires annotations that are not usually 

--- a/vignettes/a3_bootstrap.Rmd
+++ b/vignettes/a3_bootstrap.Rmd
@@ -54,7 +54,7 @@ cowplot::plot_grid(
   print
 ```
 
-Now we can compute `n.resamples` nonparametric bootstraps using function `mobster_bootstrap`, passing parameters to the calls of `mobster_fit`. This function by defaults runs the fits in parallel (using a default percentage of the available cores); parallel computing capabilities are achieved using package [easypar](https://github.com/caravagn/easypar).
+Now we can compute `n.resamples` nonparametric bootstraps using function `mobster_bootstrap`, passing parameters to the calls of `mobster_fit`. This function by defaults runs the fits in parallel (using a default percentage of the available cores); parallel computing capabilities are achieved using package [easypar](https://github.com/caravagnalab/easypar).
 
 ```{r, fig.width=9, fig.height=9, message=FALSE, warning=FALSE, eval=T}
 # The returned object contains also the list of bootstrap resamples, and the fits.

--- a/vignettes/a6_CloneTrees.Rmd
+++ b/vignettes/a6_CloneTrees.Rmd
@@ -20,8 +20,8 @@ knitr::opts_chunk$set(
 
 
 <!-- <center> -->
-<!-- <a href="https://caravagn.github.io/mobster"><img src="https://caravagn.github.io/mobster/reference/figures/logo.png" width=77px height=91px></img></a> -->
-<!-- <a href="https://caravagn.github.io/ctree"><img src="https://caravagn.github.io/ctree/reference/figures/logo.png" width=77px height=91px></img></a> -->
+<!-- <a href="https://caravagnalab.github.io/mobster"><img src="https://caravagnalab.github.io/mobster/reference/figures/logo.png" width=77px height=91px></img></a> -->
+<!-- <a href="https://caravagnalab.github.io/ctree"><img src="https://caravagnalab.github.io/ctree/reference/figures/logo.png" width=77px height=91px></img></a> -->
 <!-- </center> -->
 <!-- <br> -->
 
@@ -31,7 +31,7 @@ library(tidyr)
 library(dplyr)
 ```
 
-Clone trees from `mobster` fits can be computing using the internal interface with [ctree](https://caravagn.github.io/ctree).
+Clone trees from `mobster` fits can be computing using the internal interface with [ctree](https://caravagnalab.github.io/ctree).
 
 You need to have drivers annotated your object if you want to use `ctree`, and every `driver_label` has to be unique, as it will be used as the `variantID` column to identify the driver event.
 

--- a/vignettes/mobster.Rmd
+++ b/vignettes/mobster.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(
 ```
 
 <center>
-<a href="https://caravagn.github.io/mobster"><img src="https://caravagn.github.io/mobster/reference/figures/logo.png" width=77px height=91px></img></a>
+<a href="https://caravagnalab.github.io/mobster"><img src="https://caravagnalab.github.io/mobster/reference/figures/logo.png" width=77px height=91px></img></a>
 </center>
 <br>
 
@@ -69,7 +69,7 @@ cowplot::plot_grid(
 )
 ```
 
-The plot shows the fit (right) of a simulated subclonal expansion (left, Muller plot with [ggmuller](https://cran.r-project.org/web/packages/ggmuller/vignettes/ggmuller.html)); `C2`, the subclone at `~30%` allelic frequency is outgrowing an ancestral clonal population `C1`, at `~50%` allelic frequency (heterozygous mutations). Their dynamics are consistent with what we [expect from the interplay of positive selection between clones and neutral evolution within each clone](https://caravagn.github.io/mobster/articles/Example_tumour_simulation.html).
+The plot shows the fit (right) of a simulated subclonal expansion (left, Muller plot with [ggmuller](https://cran.r-project.org/web/packages/ggmuller/vignettes/ggmuller.html)); `C2`, the subclone at `~30%` allelic frequency is outgrowing an ancestral clonal population `C1`, at `~50%` allelic frequency (heterozygous mutations). Their dynamics are consistent with what we [expect from the interplay of positive selection between clones and neutral evolution within each clone](https://caravagnalab.github.io/mobster/articles/Example_tumour_simulation.html).
 
 Inspired from both _mathematical modelling of evolutionary processes_ and _Machine Learning_, the  signal is modeled as mixture density with two types of distributions:
 
@@ -82,6 +82,6 @@ S3 objects are defined to perform easy visualization of the data and aid compari
 
 This is a _model-based_ approach to analyse cancer data, meaning that a power law tail is used to integrate evolutionary dynamics in this traditional clustering problem. Results from `mobster` deconvolution can be used to reconstruct the clonal architecture of a tumour (_subclonal deconvolution_) and identify patterns of functional heterogeneity (subclones under positive selection). 
 
-A number of [vignettes](https://caravagn.github.io/mobster/articles/) are available to help you using `mobster`; for a set of real case studies check out the Supplementary Data repository hosted at the [Sottoriva Lab Github page](https://github.com/sottorivalab)
+A number of [vignettes](https://caravagnalab.github.io/mobster/articles/) are available to help you using `mobster`; for a set of real case studies check out the Supplementary Data repository hosted at the [Sottoriva Lab Github page](https://github.com/sottorivalab)
 
 


### PR DESCRIPTION
Links to https://caravagn.github.io have been replaced with links to https://caravagnalab.github.io